### PR TITLE
multiple extension types on style libraries, choose multiple style li…

### DIFF
--- a/sites/all/modules/custom/style_library_entity/forms/crud.forms.inc
+++ b/sites/all/modules/custom/style_library_entity/forms/crud.forms.inc
@@ -98,21 +98,22 @@ function style_library_entity_form($form, &$form_state, $entity_id, $op, $type) 
         if(isset($info['required']) && $info['required']){
           $form['style_library_entity_properties'][$name]['#required'] = TRUE;
         }
-        if ($name == 'extension_type') {
-          $form['style_library_entity_properties'][$name]['#type'] = 'select';
-          $form['style_library_entity_properties'][$name]['#options'] = [
-            '' => '- None -',
-            'civicrm' => 'CiviCRM',
-            'superfish' => 'Superfish',
-            'webform' => 'Webform',
-          ];
-          unset($form['style_library_entity_properties'][$name]['#size']);
-        }
         if ($name == 'type') {
           $form['style_library_entity_properties'][$name]['#default_value'] = $op == 'update' ? $entity->type : $type;
         }
       } // end if isset widget
     } // end foreach child
+
+    if (!empty($form['field_style_library_ext_types'])) {
+      $form['field_style_library_ext_types']['#weight'] = -9998;
+      foreach ($form['field_style_library_ext_types']['und'] as $index => $fapi_array) {
+        if (is_numeric($index) && $fapi_array['#field_name'] == 'field_style_library_ext_types') {
+          $form['field_style_library_ext_types']['und'][$index]['value']['#type'] = 'select';
+          $form['field_style_library_ext_types']['und'][$index]['value']['#options'] = ['' => '- None -', 'civicrm' => 'CiviCRM', 'superfish' => 'Superfish', 'webform' => 'Webform'];
+          unset($form['field_style_library_ext_types']['und'][$index]['value']['#size']);
+        }
+      }
+    }
 
     $form['actions'] = array(
       '#type' => 'container',

--- a/sites/all/modules/custom/style_library_entity/includes/StyleLibraryEntity.php
+++ b/sites/all/modules/custom/style_library_entity/includes/StyleLibraryEntity.php
@@ -182,16 +182,6 @@ class StyleLibraryEntityMetadataController extends EntityDefaultMetadataControll
       'widget' => 'textfield',
       'required' => TRUE,
     );
-    $info[$this->type]['properties']['extension_type'] = array(
-      'label' => t("Extension Type"),
-      'type' => 'text',
-      'description' => t("Theme Extension Type. AT theme extensions generate select lists for choosing style libraries based on this field. For example, the Superfish Menu extension will allow section of all style librares of type Superfish"),
-      'schema field' => 'extension_type',
-      'getter callback' => 'entity_property_verbatim_get',
-      'setter callback' => 'entity_property_verbatim_set',
-      'widget' => 'textfield',
-      'required' => FALSE,
-    );
     $info[$this->type]['properties']['enabled'] = array(
       'label' => t("Enabled"),
       'type' => 'integer',

--- a/sites/all/modules/custom/style_library_entity/style_library_entity.install
+++ b/sites/all/modules/custom/style_library_entity/style_library_entity.install
@@ -72,11 +72,6 @@ function style_library_entity_schema() {
         'type' => 'varchar',
         'length' => '128',
       ),
-      'extension_type' => array(
-        'description' => 'Theme extension type',
-        'type' => 'varchar',
-        'length' => '92',
-      ),
       'enabled' => array(
         'description' => 'Enabled',
         'type' => 'int',
@@ -144,4 +139,13 @@ function style_library_entity_schema() {
   );
 
   return $schema;
+}
+
+/**
+ * Remove Extension Type column from style_library_entity table
+ */
+function style_library_entity_update_7001(&$sandbox) {
+  if (db_field_exists('style_library_entity', 'extension_type')) {
+    db_drop_field('style_library_entity', 'extension_type');
+  }
 }

--- a/sites/all/modules/custom/style_library_entity/style_library_entity.module
+++ b/sites/all/modules/custom/style_library_entity/style_library_entity.module
@@ -402,6 +402,54 @@ function style_library_entity_views_api() {
  */
 function style_library_entity_entity_insert($entity, $type) {
   if ($type == 'style_library_entity_type') {
+    // add extension type field
+    if(!field_info_field('field_style_library_ext_types')) {
+      $field = [
+        'translatable' => '0',
+        'settings' => array(
+          'max_length' => '255',
+        ),
+        'field_name' => 'field_style_library_ext_types',
+        'type' => 'text',
+        'active' => '1',
+        'locked' => '0',
+        'cardinality' => '-1',
+      ];
+      field_create_field($field);
+    }
+
+    // create instance
+    $instance = array(
+      'label' => 'Extension Type',
+      'widget' => array(
+        'weight' => '33',
+        'type' => 'text_textfield',
+        'active' => 1,
+        'settings' => array(
+          'size' => '60',
+        ),
+      ),
+      'settings' => array(
+        'text_processing' => '0',
+        'user_register_form' => FALSE,
+      ),
+      'display' => array(
+        'default' => array(
+          'label' => 'above',
+          'type' => 'text_default',
+          'settings' => array(),
+          'weight' => 4,
+        ),
+      ),
+      'required' => 0,
+      'description' => '',
+      'default_value' => NULL,
+      'field_name' => 'field_style_library_ext_types',
+      'entity_type' => 'style_library_entity',
+      'bundle' => $entity->type,
+    );
+    field_create_instance($instance);
+
     // add css file field
     if(!field_info_field('field_style_library_css')) {
       $field = [
@@ -550,7 +598,31 @@ function style_library_entity_entity_insert($entity, $type) {
     );
     field_create_instance($instance);
   }
+}
 
+/**
+ * Implements hook_entity_delete().
+ *
+ * Delete all style library entities of bundle type being deleted.
+ *
+ * @param $entity
+ * @param $type
+ */
+function style_library_entity_entity_delete($entity, $type) {
+  if ($type == 'style_library_entity_type') {
+    $query = new EntityFieldQuery();
+    $query->entityCondition('entity_type', 'style_library_entity');
+    $query->entityCondition('bundle', $entity->type);
+    try {
+      $results = $query->execute();
+    }
+    catch (Exception $e) {
+      watchdog('style_library_entity', $e->getMessage());
+    }
+    if (!empty($results['style_library_entity'])) {
+      entity_delete_multiple('style_library_entity', array_keys($results['style_library_entity']));
+    }
+  }
 }
 
 /**
@@ -642,14 +714,14 @@ function style_library_entity_get_style_libraries($type = '', $bundle = '', $ena
     $query->entityCondition('bundle', $bundle);
   }
   if (!empty($type)) {
-    $query->propertyCondition('extension_type', 'civicrm');
+    $query->fieldCondition('field_style_library_ext_types', 'value', $type);
   }
   $query->propertyCondition('enabled', $enabled);
   try {
     $results = $query->execute();
   }
   catch (Exception $e) {
-    watchdog('style_entity_library', $e->getMessage());
+    watchdog('style_library_entity', $e->getMessage());
   }
   if (!empty($results['style_library_entity'])) {
     $style_libraries = entity_load('style_library_entity', array_keys($results['style_library_entity']));

--- a/sites/all/themes/nubay/template.php
+++ b/sites/all/themes/nubay/template.php
@@ -20,12 +20,14 @@ function nubay_preprocess_page(&$vars) {
     if (module_exists('style_library_entity')) {
       $civicrm_extension_enabled = theme_get_setting('nubay_civicrm_enable');
       if (!empty($civicrm_extension_enabled)) {
-        $style_library_id = theme_get_setting('nubay_civicrm_style_library');
-        if (!empty($style_library_id)) {
+        $style_library_ids = theme_get_setting('nubay_civicrm_style_library');
+        if (!empty($style_library_ids)) {
           try {
-            $style_library = entity_load_single('style_library_entity', $style_library_id);
-            style_library_entity_add_style_library_css_to_theme($style_library);
-            style_library_entity_add_style_library_js_to_theme($style_library);
+            foreach ($style_library_ids as $style_library_id) {
+              $style_library = entity_load_single('style_library_entity', $style_library_id);
+              style_library_entity_add_style_library_css_to_theme($style_library);
+              style_library_entity_add_style_library_js_to_theme($style_library);
+            }
           }
           catch (Exception $e) {
             watchdog('nubay_theme_extension', $e->getMessage());
@@ -57,12 +59,14 @@ function nubay_preprocess_block(&$vars) {
     $superfish_extension_enabled = theme_get_setting('nubay_superfish_enable');
     if (!empty($superfish_extension_enabled)) {
       if (strpos($vars['block_html_id'], 'superfish') !== FALSE) {
-        $style_library_id = theme_get_setting('nubay_superfish_style_library');
-        if (!empty($style_library_id)) {
+        $style_library_ids = theme_get_setting('nubay_superfish_style_library');
+        if (!empty($style_library_ids)) {
           try {
-            $style_library = entity_load_single('style_library_entity', $style_library_id);
-            style_library_entity_add_style_library_css_to_theme($style_library);
-            style_library_entity_add_style_library_js_to_theme($style_library);
+            foreach ($style_library_ids as $style_library_id) {
+              $style_library = entity_load_single('style_library_entity', $style_library_id);
+              style_library_entity_add_style_library_css_to_theme($style_library);
+              style_library_entity_add_style_library_js_to_theme($style_library);
+            }
           }
           catch (Exception $e) {
             watchdog('nubay_theme_extension', $e->getMessage());
@@ -86,12 +90,14 @@ function nubay_form_alter(&$form, &$form_state, $form_id) {
   // add Webform style library css/js to theme
   if (strpos($form_id, 'webform_client_form') === 0) {
     if (module_exists('style_library_entity')) {
-      $style_library_id = theme_get_setting('nubay_webform_style_library');
-      if (!empty($style_library_id)) {
+      $style_library_ids = theme_get_setting('nubay_webform_style_library');
+      if (!empty($style_library_ids)) {
         try {
-          $style_library = entity_load_single('style_library_entity', $style_library_id);
-          style_library_entity_add_style_library_css_to_theme($style_library);
-          style_library_entity_add_style_library_js_to_theme($style_library);
+          foreach ($style_library_ids as $style_library_id) {
+            $style_library = entity_load_single('style_library_entity', $style_library_id);
+            style_library_entity_add_style_library_css_to_theme($style_library);
+            style_library_entity_add_style_library_js_to_theme($style_library);
+          }
         }
         catch (Exception $e) {
           watchdog('nubay_theme_extension', $e->getMessage());

--- a/sites/all/themes/nubay/theme-settings.php
+++ b/sites/all/themes/nubay/theme-settings.php
@@ -992,25 +992,16 @@ function nubay_superfish_styles_form(&$form, &$form_state) {
 
   if (module_exists('style_library_entity')) {
     $library_options = ['' => '- None -'];
-    $query = new EntityFieldQuery();
-    $results = $query->entityCondition('entity_type', 'style_library_entity')
-      ->propertyCondition('extension_type', 'superfish')
-      ->propertyCondition('enabled', 1)
-      ->execute();
+    $library_options += style_library_entity_get_style_libraries('superfish');
 
-    if (!empty($results['style_library_entity'])) {
-      $style_libraries = entity_load('style_library_entity', array_keys($results['style_library_entity']));
-      foreach ($style_libraries as $style_library) {
-        $library_options[$style_library->slid] = $style_library->name;
-      }
-    }
-
-    $default_library_id = theme_get_setting('nubay_superfish_style_library');
+    $default_library_ids = theme_get_setting('nubay_superfish_style_library');
     try {
-      if (!empty($default_library_id)) {
-        $default_library = entity_load_single('style_library_entity', $default_library_id);
-        if (empty($default_library->enabled)) {
-          $default_library_id = '';
+      if (!empty($default_library_ids)) {
+        foreach ($default_library_ids as $delta => $default_library_id) {
+          $default_library = entity_load_single('style_library_entity', $default_library_id);
+          if (empty($default_library->enabled)) {
+            unset($default_library_ids[$delta]);
+          }
         }
       }
     }
@@ -1021,9 +1012,10 @@ function nubay_superfish_styles_form(&$form, &$form_state) {
     $form['at']['nubaystyles_superfish']['superfish']['nubay_superfish_style_library'] = [
       '#type'        => 'select',
       '#title'       => 'Style Libraries',
-      '#description' => 'Choose a pre-configured style library',
+      '#description' => 'Choose pre-configured style libraries',
       '#options'     => $library_options,
-      '#default_value' => $default_library_id,
+      '#default_value' => $default_library_ids,
+      '#multiple' => TRUE,
     ];
   }
 
@@ -1139,12 +1131,14 @@ function nubay_webform_styles_form(&$form, &$form_state) {
     $library_options = ['' => '- None -'];
     $library_options += style_library_entity_get_style_libraries('webform');
 
-    $default_library_id = theme_get_setting('nubay_webform_style_library');
+    $default_library_ids = theme_get_setting('nubay_webform_style_library');
     try {
-      if (!empty($default_library_id)) {
-        $default_library = entity_load_single('style_library_entity', $default_library_id);
-        if (empty($default_library->enabled)) {
-          $default_library_id = '';
+      if (!empty($default_library_ids)) {
+        foreach ($default_library_ids as $delta => $default_library_id) {
+          $default_library = entity_load_single('style_library_entity', $default_library_id);
+          if (empty($default_library->enabled)) {
+            unset($default_library_ids[$delta]);
+          }
         }
       }
     }
@@ -1155,9 +1149,10 @@ function nubay_webform_styles_form(&$form, &$form_state) {
     $form['at']['nubaystyles_webform']['webform']['nubay_webform_style_library'] = [
       '#type'        => 'select',
       '#title'       => 'Style Libraries',
-      '#description' => 'Choose a pre-configured style library',
+      '#description' => 'Choose pre-configured style libraries',
       '#options'     => $library_options,
-      '#default_value' => $default_library_id,
+      '#default_value' => $default_library_ids,
+      '#multiple' => TRUE,
     ];
   }
 
@@ -1226,12 +1221,14 @@ function nubay_civicrm_styles_form(&$form, &$form_state) {
     $library_options = ['' => '- None -'];
     $library_options += style_library_entity_get_style_libraries('civicrm');
 
-    $default_library_id = theme_get_setting('nubay_civicrm_style_library');
+    $default_library_ids = theme_get_setting('nubay_civicrm_style_library');
     try {
-      if (!empty($default_library_id)) {
-        $default_library = entity_load_single('style_library_entity', $default_library_id);
-        if (empty($default_library->enabled)) {
-          $default_library_id = '';
+      if (!empty($default_library_ids)) {
+        foreach ($default_library_ids as $delta => $default_library_id) {
+          $default_library = entity_load_single('style_library_entity', $default_library_id);
+          if (empty($default_library->enabled)) {
+            unset($default_library_ids[$delta]);
+          }
         }
       }
     }
@@ -1242,9 +1239,10 @@ function nubay_civicrm_styles_form(&$form, &$form_state) {
     $form['at']['nubaystyles_civicrm']['civicrm']['nubay_civicrm_style_library'] = [
       '#type'        => 'select',
       '#title'       => 'Style Libraries',
-      '#description' => 'Choose a pre-configured style library',
+      '#description' => 'Choose pre-configured style libraries',
       '#options'     => $library_options,
-      '#default_value' => $default_library_id,
+      '#default_value' => $default_library_ids,
+      '#multiple' => TRUE,
     ];
   }
 


### PR DESCRIPTION
…braries from theme extensions

requires running database updates after code update. 

Best to remove existing Style Library Entity Types, and re-create....but if not wanting to do that because style libraries in use for clients, then I can manually configure existing types if necessary.